### PR TITLE
Corregidos errores de inicio de sesión en MongoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build/
 dist/
 sniim.egg-info
 *.pyc
+.idea/
+.venv
+venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
 FROM python:3.5
 
+ENV CONNECT_WITH_USER=${CONNECT_WITH_USER:-True}
+ENV MONGO_HOST=${MONGO_HOST:-mongo}
+ENV MONGO_PORT=${MONGO_PORT:-27017}
+ENV MONGO_DATABASE=${MONGO_DATABASE:-central}
+ENV MONGO_USER=${MONGO_USER:-central}
+ENV MONGO_PASSWORD=${MONGO_PASSWORD:-secret}
+ENV HISTORIAL=${HISTORIAL:-true}
+
 RUN mkdir precios
 COPY . precios/
 
 WORKDIR /precios
 RUN pip install -r requirements.txt && ls && chmod 777 start.sh
+
+
 
 ENTRYPOINT ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ Para ejecutar el scraper en una instancia Docker correr el siguiente comando:
 docker run --name sniim -e HISTORIAL=true -e MONGO_HOST=172.17.0.2 -e MONGO_PORT=27017 -e MONGO_DATABASE=central -e MONGO_USER=central -e MONGO_PASSWORD=secret -d mxabierto/scrapper-sniim
 ```
 
+Para ejecutar el scraper junto con una instancia de MongoDB configurada automaticamente, ejecuta el siguiente comando:
+```sh
+docker compose up -d
+```
+
 ### Configuración
 
 Para configurar la conectividad con el servidor Mongo y modo de ejecución se necesita configurar el scraper con las siguientes variables de entorno:
@@ -115,3 +120,4 @@ Para configurar la conectividad con el servidor Mongo y modo de ejecución se ne
 - **MONGO_USER**: Usuario de conexion al servidor mongo.
 - **MONGO_PASSWORD**: Password para el usuario de conexion al servidor mongo.
 - **MONGO_DATABASE**: Nombre de la base de datos en el servidor mongo.
+- **CONNECT_WITH_USER**: Bandera para permitir la conexión a MongoDB sin autenticación. Desactivado por defecto.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  mongo:
+    image: mongo:latest
+    container_name: mongo
+    environment:
+      MONGO_INITDB_DATABASE: "central"
+      MONGO_INITDB_ROOT_USERNAME: "root"
+      MONGO_INITDB_ROOT_PASSWORD: "changeme"
+    volumes:
+      - ./init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
+      - mongo_data:/data/db
+    ports:
+      - "27017:27017"
+
+  sniim:
+    build: .
+    container_name: sniim
+    environment:
+      HISTORIAL: "true"
+      MONGO_HOST: "mongo"
+      MONGO_PORT: "27017"
+      MONGO_DATABASE: "central"
+      MONGO_USER: "scrapper"
+      MONGO_PASSWORD: "password"
+      CONNECT_WITH_USER: "True"
+    depends_on:
+      - mongo
+    restart: always
+
+volumes:
+  mongo_data:

--- a/init-mongo.js
+++ b/init-mongo.js
@@ -1,0 +1,10 @@
+db.createUser({
+  user: 'scrapper',
+  pwd: 'password',
+  roles: [
+    {
+      role: 'readWrite',
+      db: 'central'
+    }
+  ]
+})

--- a/sniim/db/mongo.py
+++ b/sniim/db/mongo.py
@@ -1,27 +1,27 @@
 import os
-from urllib.parse import quote_plus
+
 from pymongo import MongoClient
 
 
 class Mongoclient:
     def __init__(self, *args, db_collection=None):
-        self.host = os.environ.get('MONGO_HOST', '0.0.0.0')
+        self.host = os.environ.get('MONGO_HOST', '127.0.0.1')
         self.port = os.environ.get('MONGO_PORT', '27017')
-        if os.environ.get('CONNECT_WITH_USER', 'False') == 'True':
+        if os.environ.get('CONNECT_WITH_USER', 'True') == 'True':
             self.user = os.environ.get('MONGO_USER', 'central')
             self.password = os.environ.get('MONGO_PASSWORD', 'central')
 
-        self.client = MongoClient(self._connection_string)
         self.db_name = os.environ.get('MONGO_DATABASE', 'central')
         self.db_collection = db_collection
+        self.client = MongoClient(self._connection_string)
 
         self.db = self.client[self.db_name]
         self.collection = self.db[self.db_collection]
 
     @property
     def _connection_string(self):
-        if os.environ.get('CONNECT_WITH_USER', 'False') == 'True':
-            return "mongodb://{0}:{1}@{2}:{3}".format(self.user, self.password, self.host, self.port)
+        if os.environ.get('CONNECT_WITH_USER', 'True') == 'True':
+            return "mongodb://{0}:{1}@{2}:{3}/?authSource={4}".format(self.user, self.password, self.host, self.port, self.db_name)
         else:
             return "mongodb://{0}:{1}".format(self.host, self.port)
 


### PR DESCRIPTION
Cambiado modo a autorización con usuario/contraseña para mongo (configuración más segura por defecto.
Contenedorización mejorada.
Corregido CRLF en start.sh al ejecutar en Linux o Docker Desktop con motor de ejecución en WSL2.
Se actualizó el README.md para incluir un ejemplo de cómo ejecutar el scraper con una instancia de MongoDB preconfigurada usando Docker Compose. También se añadió la descripción de una nueva variable de entorno `CONNECT_WITH_USER` para controlar la autenticación en MongoDB.